### PR TITLE
[Fix] 예제에 사용되는 DrawerComponent 의 하단 잘림 이슈

### DIFF
--- a/example/lib/components/drawer_component.dart
+++ b/example/lib/components/drawer_component.dart
@@ -56,6 +56,7 @@ class _DrawerComponentState extends State<DrawerComponent> {
   @override
   Widget build(BuildContext context) {
     var mediaQuery = MediaQuery.of(context);
+    var bottomPadding = mediaQuery.padding.bottom;
     var children = <Widget>[];
 
     children.addAll([
@@ -64,12 +65,12 @@ class _DrawerComponentState extends State<DrawerComponent> {
           top: 0,
           left: 0,
           right: 0,
-          bottom: _drawerHeight.toDouble(),
+          bottom: _drawerHeight.toDouble() + bottomPadding,
           child: widget.body),
       Positioned(
           left: 0,
           right: 0,
-          bottom: 0,
+          bottom: bottomPadding,
           child: GestureDetector(
               onTap: () {},
               onVerticalDragUpdate: onVerticalDragUpdate,


### PR DESCRIPTION
## Change Log
Android 15에서 edge-to-edge 로 인해 앱 화면 일부가 가려지는 이슈가 종종 보이는데
해당 라이브러리의 example 에서도 발생하는 것이 보여 bottomPadding을 간단하게 넣어봤습니다.
이슈로 제보드리기에 너무 간단한 이슈이기도하고 작업 내용 PR도 환영해주신다고 적혀 있어서 조심스럽게 PR 남겨봅니다.
+) 항상 라이브러리 너무 잘쓰고 있습니다!

[적용 전]
<img src="https://github.com/user-attachments/assets/7e46760d-2f28-4dda-98f9-03b9ece649d9" width="200px"/>

[적용 후]
<img src="https://github.com/user-attachments/assets/a772ab49-3b71-4bab-b618-18615a8e8412" width="200px"/>

## Issue Number


## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
