### PR TITLE
feat: add bounds extension for KakaoMapController

### DIFF
--- a/lib/controller/extensions/bounds.dart
+++ b/lib/controller/extensions/bounds.dart
@@ -1,0 +1,27 @@
+part of '../../kakao_map_sdk.dart';
+
+///
+extension KakaoMapControllerBoundsExtension on KakaoMapController {
+  /// 화면에 보이는 지도 영역의 경계를 가져오는 함수입니다
+  Future<LatLngBounds?> getBounds(BuildContext context) async {
+    /// 지도 위젯을 포함하는 RenderBox 객체입니다
+    final renderBox = context.findRenderObject();
+
+    if (renderBox is! RenderBox) {
+      return null;
+    }
+
+    final size = renderBox.size;
+
+    final [ne, sw] = await Future.wait([
+      fromScreenPoint(size.width.toInt(), 0),
+      fromScreenPoint(0, size.height.toInt())
+    ]);
+
+    if (ne == null || sw == null) {
+      return null;
+    }
+
+    return LatLngBounds._(ne, sw);
+  }
+}

--- a/lib/kakao_map_sdk.dart
+++ b/lib/kakao_map_sdk.dart
@@ -28,6 +28,8 @@ part 'controller/overlay/route_controller.dart';
 part 'controller/overlay/shape_controller.dart';
 part 'controller/overlay/tracking_controller.dart';
 
+part 'controller/extensions/bounds.dart';
+
 /* exception */
 part 'exception/duplicated_overlay_exception.dart';
 part 'exception/overlay_style_registration_failed_error.dart';
@@ -49,6 +51,7 @@ part 'models/base/messageable.dart';
 part 'models/camera/camera_animation.dart';
 part 'models/camera/camera_position.dart';
 part 'models/camera/camera_update.dart';
+part 'models/camera/lat_lng_bounds.dart';
 part 'models/geolocation/latlng.dart';
 
 part 'models/label/badge.dart';

--- a/lib/models/camera/lat_lng_bounds.dart
+++ b/lib/models/camera/lat_lng_bounds.dart
@@ -1,0 +1,46 @@
+part of '../../kakao_map_sdk.dart';
+
+/// 화면에 보이는 지도 영역의 경계를 정의할 때 사용하는 객체입니다
+class LatLngBounds with KMessageable {
+  /// north-east - 지도의 보이는 영역 중 오른쪽 위 모서리 지점입니다
+  final LatLng ne;
+
+  /// south-west - 지도의 보이는 영역 중 왼쪽 아래 모서리 지점입니다
+  final LatLng sw;
+
+  /// north-west - 왼쪽 위 모서리 지점입니다
+  LatLng get nw => LatLng(ne.latitude, sw.longitude);
+
+  /// south-east - 오른쪽 아래 모서리 지점입니다
+  LatLng get se => LatLng(sw.latitude, ne.longitude);
+
+  LatLngBounds._(this.ne, this.sw);
+
+  factory LatLngBounds.fromMessageable(dynamic payload) => LatLngBounds._(
+        LatLng.fromMessageable(payload['ne']),
+        LatLng.fromMessageable(payload['sw']),
+      );
+
+  /// REST API의 'rect' 파라미터로 사용할 수 있는 문자열을 생성합니다
+  String toRect() {
+    return '${sw.longitude},${sw.latitude},${ne.longitude},${ne.latitude}';
+  }
+
+  LatLngBounds copyWith({LatLng? ne, LatLng? sw}) =>
+      LatLngBounds._(ne ?? this.ne, sw ?? this.sw);
+
+  @override
+  Map<String, dynamic> toMessageable() => {
+        "ne": ne.toMessageable(),
+        "sw": sw.toMessageable(),
+      };
+
+  @override
+  int get hashCode => ne.hashCode ^ sw.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is LatLngBounds && other.ne == ne && other.sw == sw;
+  }
+}


### PR DESCRIPTION
## Summary

이 PR은 `KakaoMapController`에 `getBounds(BuildContext context)` extension 메서드를 추가합니다.

이 메서드는 렌더링된 지도 위젯의 크기와 기존 `fromScreenPoint` API를 사용하여 현재 화면에 보이는 지도 영역의 경계를 계산합니다.

## Changes

- `LatLngBounds` 모델을 추가했습니다.
- `KakaoMapControllerBoundsExtension`을 추가했습니다.
- `getBounds(BuildContext context)` 메서드를 추가했습니다.
- 새 파일들을 `kakao_map_sdk.dart`에 연결했습니다.

## Why

Kakao Maps JavaScript API에는 `getBounds()`가 제공되지만, 현재 Flutter 플러그인에는 이와 유사한 helper 메서드가 제공되지 않습니다.

이 메서드는 다음과 같은 경우에 유용합니다.

- 현재 화면에 보이는 지도 영역 안의 항목만 가져오는 경우
- 지도 이동 후 검색 결과를 업데이트하는 경우
- viewport 기반 필터링 또는 클러스터링을 구현하는 경우
- Kakao REST API 요청에 사용할 `rect` 파라미터를 생성하는 경우

## Notes

`BuildContext`는 렌더링된 지도 위젯 또는 지도와 동일한 크기를 가진 위젯의 context여야 합니다.

## Testing

- `dart format`을 실행했습니다.
- `flutter analyze lib`를 실행했습니다.
- path dependency를 사용하여 로컬 환경에서 테스트했습니다.
- `controller.getBounds(context)`가 화면에 보이는 지도 영역의 경계를 반환하는 것을 확인했습니다.
- 지도를 이동한 후 반환되는 좌표가 변경되는 것을 확인했습니다.
