### PR TITLE
[Fix] Handle NSNull for optional image payloads on iOS

### DIFF
--- a/ios/kakao_map_sdk/Sources/kakao_map_sdk/converter/LabelTypeConverter.swift
+++ b/ios/kakao_map_sdk/Sources/kakao_map_sdk/converter/LabelTypeConverter.swift
@@ -48,7 +48,7 @@ extension PoiTextStyle {
 extension PoiIconStyle {
     convenience init(payload: [String: Any]) {
         let transition = asPoiTransition(payload: castSafty(payload["iconTransition"], caster: asDict))
-        let symbol = payload["icon"].flatMap(asDict).flatMap(asImage)
+        let symbol = castSafty(payload["icon"], caster: asDict).flatMap(asImage)
 
         self.init(
             symbol: symbol,
@@ -198,7 +198,7 @@ extension WaveTextOptions {
 extension PoiBadge {
     convenience init(payload: [String: Any]) {
         let id = castSafty(payload["id"], caster: asString) ?? UUID().uuidString
-        let image = payload["image"].flatMap(asDict).flatMap(asImage)
+        let image = castSafty(payload["image"], caster: asDict).flatMap(asImage)
         let offset = CGPoint(x: asDouble(payload["offsetX"]!), y: asDouble(payload["offsetY"]!))
         let zOrder = castSafty(payload["zOrder"], caster: asInt) ?? 0
         self.init(badgeID: id, image: image, offset: offset, zOrder: zOrder)


### PR DESCRIPTION
## Change Log
PoiIconStyle과 PoiBadge가 optional 이미지를 읽을 때 castSafty를 사용하도록 수정하였습니다.

## Issue Number
#62 
## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
